### PR TITLE
140 quic fire from file fuel height bug

### DIFF
--- a/quicfire_tools/inputs.py
+++ b/quicfire_tools/inputs.py
@@ -1956,10 +1956,10 @@ class QUIC_fire(InputFile):
             fuel_moisture = float(lines[current_line].strip())
 
         # Read fuel height
-        current_line += 1
-        fuel_height_flag = 0
         if fuel_density_flag == 1:
             fuel_height_flag = int(lines[current_line].strip().split("!")[0])
+        else:
+            fuel_height_flag = fuel_density_flag
         fuel_height = None
         if fuel_density_flag == 1 and fuel_moisture_flag == 1:
             current_line += 1

--- a/quicfire_tools/inputs.py
+++ b/quicfire_tools/inputs.py
@@ -1,6 +1,7 @@
 """
 QUIC-Fire Tools Simulation Input Module
 """
+
 from __future__ import annotations
 
 # Core Imports
@@ -1956,6 +1957,7 @@ class QUIC_fire(InputFile):
             fuel_moisture = float(lines[current_line].strip())
 
         # Read fuel height
+        current_line += 1
         if fuel_density_flag == 1:
             fuel_height_flag = int(lines[current_line].strip().split("!")[0])
         else:


### PR DESCRIPTION
This fixed a bug where a fuel_heigh_flag of 0 was being assigned if the fuel height line was not present, which is not accepted by quicfire.