### PR TITLE
Util function write_dat_file

### DIFF
--- a/quicfire_tools/utils.py
+++ b/quicfire_tools/utils.py
@@ -113,10 +113,26 @@ def write_dat_file(array: ndarray, filename: Path |str, dtype: type = np.float32
     ----------
     array : ndarray
         The array written to the .dat file
+        The function uses Fortran row-major order to write
+        an array of any dimension into linear form (see example)
     filename : Path or str
         The path to the .dat file to read.
     dtype : type
         The desired data type of the array written to the .dat file
+
+    Example
+    ----------
+    If you have an array N x M:     | a11, a12, a13 |
+                                    | a21, a22, a23 |
+
+    Then this function will write it as:
+                                    [ a11, a12, a13, a21, a22, a23 ]
+
+    In order to modify the values of a 3D array of N x M x Z by loading from an existing dat file,
+    Use the read_dat_file() with the shape argument as a 1D array of length = (N)x(M)x(Z)
+    Then modify the numpy array and write back to .dat
+    This will preserve the order of the data when it is read and then written
+
 
     """
     if isinstance(filename, str):

--- a/quicfire_tools/utils.py
+++ b/quicfire_tools/utils.py
@@ -105,6 +105,27 @@ def read_dat_file(filename: Path | str, shape: tuple[int]) -> ndarray:
 
     return arr
 
+def write_dat_file(array: ndarray, filename: Path |str, dtype: type = np.float32):
+    """
+    Write a numpy array into a .dat file
+
+    Parameters
+    ----------
+    array : ndarray
+        The array written to the .dat file
+    filename : Path or str
+        The path to the .dat file to read.
+    dtype : type
+        The desired data type of the array written to the .dat file
+
+    """
+    if isinstance(filename, str):
+        filename = Path(filename)
+    array = array.astype(dtype)
+
+    with FortranFile(filename, "w") as f:
+        f.write_record(array) #this will write in row-major order
+
 
 def list_default_factory():
     return []


### PR DESCRIPTION
Added a util function write_dat_file to write numpy array back into a .dat file. Operation is same as FastFuels. Added to quicfire-tools for convenience.